### PR TITLE
Handled multiple work list item creations.

### DIFF
--- a/src/app/analyze/stack/recommender/recommender.component.ts
+++ b/src/app/analyze/stack/recommender/recommender.component.ts
@@ -14,6 +14,8 @@ export class RecommenderComponent {
     @Input() recommendations;
     private recommendationsList: Array<any> = [];
 
+    private newRecommendations: Array<any> = [];
+
     constructor(private addWorkFlowService: AddWorkFlowService) {}
 
     ngOnInit() {
@@ -40,7 +42,7 @@ export class RecommenderComponent {
      */
     private handleDropDownClick(item: any, recommender: any, event: Event): void {
         if (item && item.identifier === 'CREATE_WORK_ITEM') {
-            this.handleCreateWorkItemAction(recommender);
+            this.handleCreateWorkItemAction([recommender]);
         }
         event.preventDefault();
     }
@@ -106,15 +108,39 @@ export class RecommenderComponent {
      *  handleCreateWorkItemAction - takes recommendation and returns nothing
      *  Creates work items in specified format to be consumed for POST request 
      */
-    private handleCreateWorkItemAction(recommendation: any): void {
+    private handleCreateWorkItemAction(recommendations: Array<any>): void {
         let workItems = [];
-        if (recommendation) {
-            let item: any = {
-                title: recommendation['action'],
-                description: recommendation['message']
-            };
-            workItems.push(item);
+        let length: number = recommendations.length;
+        if (recommendations && length > 0) {
+            for (let i: number = 0; i < length; ++ i) {
+                let item: any = {
+                    title: recommendations[i]['action'],
+                    description: recommendations[i]['message']
+                };
+                workItems.push(item);
+            }
             this.addWorkItems(workItems);
+        }
+    }
+
+
+    /*
+     *  handleMultipleWorkItemCreation - takes and returns nothing
+     *  handles the creation of multiple work items that are checked 
+     */
+    private handleMultipleWorkItemCreation(event: Event): void {
+        if (this.newRecommendations.length > 0) {
+            this.handleCreateWorkItemAction(this.newRecommendations);
+        }
+        event.preventDefault();
+    }
+
+    private handleCheckBoxChange(recommendation: any): void {
+        let index: number = this.newRecommendations.indexOf(recommendation);
+        if (index === -1) {
+            this.newRecommendations.push(recommendation);
+        } else {
+            this.newRecommendations.splice(index, 1);
         }
     }
 
@@ -151,12 +177,13 @@ export class RecommenderComponent {
         Handles Work Item selection
         1. Toggles the selected area
      */
-    private handleWorkItemSelection(element: HTMLElement): void {
+    private handleWorkItemSelection(element: HTMLElement, recommendation: any): void {
         if (element.classList.contains('active')) {
             element.classList.remove('active');
         } else {
             element.classList.add('active');
         }
+        this.handleCheckBoxChange(recommendation);
     }
 
 }

--- a/src/app/analyze/stack/recommender/recommender.html
+++ b/src/app/analyze/stack/recommender/recommender.html
@@ -1,8 +1,8 @@
-<div class="row recommendation-header">
+<div class="recommendation-header">
     <h1 class="keep-left">Recommendations</h1>
-    <div class="keep-right recommender-action-group">
-        <button class="btn btn-default keep-left create-work-item" type="button">Create Work Item</button>
-        <button class="btn btn-link dropdown-toggle keep-right" type="button" id="dropdownKebabRight2" data-toggle="dropdown" aria-haspopup="true"
+    <div class="keep-right recommender-action-group recommendation-group-item">
+        <button (click)="handleMultipleWorkItemCreation($event)" [ngClass]="{'btn-default disable-create-work-item': newRecommendations.length === 0, 'btn-primary': newRecommendations.length > 0}" class="btn keep-left create-work-item" type="button">Create Work Item</button>
+        <button #allRecommendation class="btn btn-link dropdown-toggle keep-right" type="button" (click)="handleRecommendationAction(allRecommendation)" data-toggle="dropdown" aria-haspopup="true"
                 aria-expanded="true">
         <span class="fa fa-ellipsis-v"></span>
         </button>
@@ -32,7 +32,7 @@
 
     <div #listGroupItem class="list-group-item list-view-pf-stacked recommendation-group-item" *ngFor="let recommendation of recommendationsList">
         <div class="list-view-pf-checkbox">
-            <input (change)="handleWorkItemSelection(listGroupItem)" type="checkbox" />
+            <input (change)="handleWorkItemSelection(listGroupItem, recommendation)" type="checkbox" />
         </div>
         <div class="list-view-pf-actions">
             <div class="dropdown pull-right dropdown-kebab-pf">

--- a/src/app/analyze/stack/recommender/recommender.scss
+++ b/src/app/analyze/stack/recommender/recommender.scss
@@ -2,7 +2,7 @@
     .recommender-action-group {
         margin-top: 20px;
         margin-bottom: 10px;
-        .create-work-item {
+        .disable-create-work-item {
             background: #fff;
             color: #ccc;
             box-shadow: none;   

--- a/src/app/analyze/stack/stack-details/stack-details.component.ts
+++ b/src/app/analyze/stack/stack-details/stack-details.component.ts
@@ -84,22 +84,48 @@ export class StackDetailsComponent implements OnInit {
 
     this.recommendations = [
       {
-        suggestion: 'Recommended',
+        suggestion: 'Recommended1',
         action: 'Upgrade',
-        message: 'Vertx Web applications have different version'
+        message: 'Vertx Web applications have different version',
+        pop: [
+          {
+            itemName: 'Create WorkItem',
+            identifier: 'CREATE_WORK_ITEM'
+          }, {
+            itemName: 'Dismiss Recommendation',
+            identifier: 'DISMISS'
+          }
+        ]
       },
       {
-        suggestion: 'Recommended',
+        suggestion: 'Recommended2',
         action: 'Downgrade',
-        message: 'Vertx Web applications have different version'
+        message: 'Vertx Web applications have different version',
+        pop: [
+          {
+            itemName: 'Create WorkItem',
+            identifier: 'CREATE_WORK_ITEM'
+          }, {
+            itemName: 'Dismiss Recommendation',
+            identifier: 'DISMISS'
+          }
+        ]
       },
       {
-        suggestion: 'Recommended',
+        suggestion: 'Recommended3',
         action: 'Remove',
-        message: 'Vertx Web applications have different version'
-      },
-      {
-        suggestion: 'Recommended',
+        message: 'Vertx Web applications have different version',
+        pop: [
+          {
+            itemName: 'Create WorkItem',
+            identifier: 'CREATE_WORK_ITEM'
+          }, {
+            itemName: 'Dismiss Recommendation',
+            identifier: 'DISMISS'
+          }
+        ]
+      }, {
+        suggestion: 'Recommended4',
         action: 'Upgrade',
         message: 'Vertx Web applications have different version',
         pop: [
@@ -113,7 +139,7 @@ export class StackDetailsComponent implements OnInit {
         ]
       },
       {
-        suggestion: 'Recommended',
+        suggestion: 'Recommended5',
         action: 'Downgrade',
         message: 'Vertx Web applications have different version',
         pop: [
@@ -127,7 +153,7 @@ export class StackDetailsComponent implements OnInit {
         ]
       },
       {
-        suggestion: 'Recommended',
+        suggestion: 'Recommended6',
         action: 'Remove',
         message: 'Vertx Web applications have different version',
         pop: [


### PR DESCRIPTION
What this commit does?

1. Enables you to add multiple work items at once by using the checkboxes.
2. It shows different UI states on enabling and disabling checkboxes
3. The Create Work Item button for creating multiple work items gets enables only if there is at least one work item checked.
4. Clicking on it creates a multiple work item that can be seen in the planner.
5. Removed the 'row' class from recommendation widget as it was having a bad look.

Tracks #6.