### PR TITLE
fix(modal-backdrop): On modal close, screen is stuck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ dist-watch/
 # NPM #
 
 npm-debug.log*
+
+.history

--- a/src/app/stack/stack-details/stack-details.component.ts
+++ b/src/app/stack/stack-details/stack-details.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnChanges, ViewChild, ViewEncapsulation, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { Modal } from 'ngx-modal';
 
 import { StackAnalysesService } from '../stack-analyses.service';
 import { getStackReportModel } from '../utils/stack-api-utils';
@@ -39,7 +40,7 @@ export class StackDetailsComponent implements OnChanges, OnInit {
     @Input() showFlags;
     @Input() openStackModalFromCard: string;
 
-    @ViewChild('stackModule') modalStackModule: any;
+    @ViewChild('stackModule') modalStackModule: Modal;
 
 
     /**
@@ -107,6 +108,7 @@ export class StackDetailsComponent implements OnChanges, OnInit {
      */
     public handleModalClose(): void {
         this.resetFields();
+        SaveState.isModalOpened = false;
     }
 
 
@@ -202,10 +204,13 @@ export class StackDetailsComponent implements OnChanges, OnInit {
     }
 
     ngOnInit() {
-        this.commonService.inshortCardClicked
-        .subscribe(response => {
-            this.showStackModal(null);
-        });
+        if (SaveState.isModalOpened === false) {
+            SaveState.isModalOpened = true;
+            this.commonService.inshortCardClicked
+            .subscribe(response => {
+                this.showStackModal(null);
+            });
+        }
     }
 
     public handleChangeFilter(filterBy: any): void {
@@ -264,7 +269,6 @@ export class StackDetailsComponent implements OnChanges, OnInit {
         this.cacheResponse = {};
         SaveState.ELEMENTS = [];
         this.openStackModalFromCard = 'false';
-        // this.dataLoaded = false;
     }
 
     private handleResponse(data: any): void {

--- a/src/app/stack/utils/SaveState.ts
+++ b/src/app/stack/utils/SaveState.ts
@@ -1,3 +1,4 @@
 export class SaveState {
     public static ELEMENTS: Array<HTMLElement> = [];
+    public static isModalOpened = false;
 }


### PR DESCRIPTION
If we open the stack report modal on click of a card in the Analytics widget in the space dashboard and then close it, the page stuck and prevents a user to click on the screen

Related to https://github.com/openshiftio/openshift.io/issues/2328