### PR TITLE
fix(dependencies): use peer dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 image:https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic%20release-b4d455.svg[Semantic Release, link="https://github.com/semantic-release/semantic-release"]
 
-**Fabric8 Recommender is a stack analysis feature.** 
+**Fabric8 Recommender is a stack analysis feature.**
 
 == Running the app
 
@@ -90,7 +90,7 @@ Here are some of the most useful/frequently used scripts you may need to run:
 == Building the app
 
 === Production build
- 
+
 To generate production build, set API URL and run build script as follows:
 
 ----
@@ -126,7 +126,7 @@ Step 1: Run `npm run watch:library` in the source directory::
 This will build fabric8-stack-analysis-ui as a library and then set up a watch task to
 rebuild any ts, html and scss files you change.
 
-Step 2: Run `npm link <path to fabric8-stack-analysis-ui>/dist-watch`::
+Step 2: Run `npm link <path to fabric8-stack-analysis-ui>/dist-watch --production`::
 In the webapp into which you are embedding. This will create a symlink from
 `node_modules/fabric8-stack-analysis-ui` to the `dist-watch` directory and install that
 symlinked node module into your webapp.
@@ -148,14 +148,14 @@ of the shadow dom, so you will normally want to place your styles in the
 `.component.LESS` file next to the html and the typescript.
 
 We use mixins to avoid polluting components with uncessary style classes, and to avoid
-an explosion of shared files.  
+an explosion of shared files.
 
 The `src/assets/stylesheets/` directory includes a `shared` directory. These are
 shared global styles that we will refactor out in to a shared library at some point.
 Only update these styles if you are making a truly global style, and are going to
-synchronise your changes across all the various UI projects.  
+synchronise your changes across all the various UI projects.
 
 == Contributing to the app
 
-The development guide is part of the link:./CONTRIBUTING.adoc[contributors' 
-instructions]. Please check it out in order to contribute to this project. 
+The development guide is part of the link:./CONTRIBUTING.adoc[contributors'
+instructions]. Please check it out in order to contribute to this project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.4.6.tgz",
       "integrity": "sha1-S4FCByTggooOg5uVpV6xp+g5GPI=",
+      "dev": true,
       "requires": {
         "tslib": "1.8.1"
       }
@@ -36,6 +37,7 @@
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.4.6.tgz",
       "integrity": "sha1-EwMf0Q3P5DiHVBmzjyESCVi8I1Q=",
+      "dev": true,
       "requires": {
         "tslib": "1.8.1"
       }
@@ -44,6 +46,7 @@
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.4.6.tgz",
       "integrity": "sha1-/mSs5CQ1wbgPSQNLfEHOjK8UpEo=",
+      "dev": true,
       "requires": {
         "tslib": "1.8.1"
       }
@@ -52,6 +55,7 @@
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@angular/http/-/http-4.4.6.tgz",
       "integrity": "sha1-CvaAxnEL3AJtlA4iXP0PalwAXQw=",
+      "dev": true,
       "requires": {
         "tslib": "1.8.1"
       }
@@ -8939,7 +8943,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -10007,6 +10012,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/ngx-base/-/ngx-base-2.3.1.tgz",
       "integrity": "sha512-EJCAgWmfBwM8pbygozrRRaojeSNp6FUHfZJydSEPLSPbja5SPB4I2LvFy/PhuZTLzg1Gw06TKhBiSXjPfs6hSQ==",
+      "dev": true,
       "requires": {
         "@angular/core": "4.4.6",
         "@angular/http": "4.4.6"
@@ -10018,9 +10024,10 @@
       "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
     },
     "ngx-fabric8-wit": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/ngx-fabric8-wit/-/ngx-fabric8-wit-6.20.0.tgz",
-      "integrity": "sha512-6IxvJdG7GSEwnKSYAVfdCvhVeY79RHkfg/WfGTR2dMAfvQE8p1lwV9GaMZq64hKtypx+GWoRlEiyjGtv0fnOow==",
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/ngx-fabric8-wit/-/ngx-fabric8-wit-6.20.3.tgz",
+      "integrity": "sha512-1hyaXmLA155Xk8ryp1onDr4HElBdES+q244bnGlQ5zS9jSklJcYwrDaYrPKmNjJz7KVeIJN7dJvrrdm8vD3OCw==",
+      "dev": true,
       "requires": {
         "@angular/core": "4.4.6",
         "@angular/forms": "4.4.6",
@@ -10034,6 +10041,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/ngx-login-client/-/ngx-login-client-1.2.6.tgz",
       "integrity": "sha512-hI/6X8ysmyMvDO8RON+VDW/doiLW6648BV+kXl9ROJMpwnXbRv2WtIJThDH8HCghgC+Ew3Yf180HS3fAhEvl2g==",
+      "dev": true,
       "requires": {
         "@angular/core": "4.4.6",
         "@angular/http": "4.4.6",
@@ -14583,6 +14591,7 @@
       "version": "5.5.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
       "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
       }
@@ -15940,7 +15949,8 @@
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
     },
     "table": {
       "version": "4.0.2",
@@ -16335,7 +16345,8 @@
     "tslib": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+      "dev": true
     },
     "tslint": {
       "version": "5.8.0",

--- a/package.json
+++ b/package.json
@@ -73,22 +73,27 @@
     "npm": ">= 5.3.0"
   },
   "dependencies": {
+    "c3": "^0.4.18",
+    "ngx-bootstrap": "^1.9.3",
+    "ngx-modal": "^0.0.29"
+  },
+  "peerDependencies": {
+    "@angular/common": "^4.4.6",
+    "@angular/core": "^4.4.6",
+    "@angular/forms": "^4.4.6",
+    "@angular/http": "^4.4.6",
+    "ngx-base": "^2.3.0",
+    "ngx-fabric8-wit": "^6.20.3",
+    "ngx-login-client": "^1.2.0",
+    "rxjs": "^5.5.2"
+  },
+  "devDependencies": {
     "@angular/common": "4.4.6",
+    "@angular/compiler": "4.4.6",
+    "@angular/compiler-cli": "4.4.6",
     "@angular/core": "4.4.6",
     "@angular/forms": "4.4.6",
     "@angular/http": "4.4.6",
-    "c3": "0.4.18",
-    "ngx-bootstrap": "^1.8.0",
-    "ngx-base": "^2.3.0",
-    "ngx-fabric8-wit": "6.20.3",
-    "ngx-login-client": "^1.2.0",
-    "ngx-modal": "^0.0.29",
-    "rxjs": "^5.0.1"
-  },
-  "peerDependencies": {},
-  "devDependencies": {
-    "@angular/compiler": "4.4.6",
-    "@angular/compiler-cli": "4.4.6",
     "@angular/platform-browser": "4.4.6",
     "@angular/platform-browser-dynamic": "4.4.6",
     "@angular/router": "4.4.6",
@@ -148,6 +153,9 @@
     "mocha": "4.0.1",
     "ngc-webpack": "3.2.2",
     "npm-run-all": "4.1.1",
+    "ngx-base": "^2.3.0",
+    "ngx-fabric8-wit": "^6.20.3",
+    "ngx-login-client": "^1.2.0",
     "optimize-js-plugin": "0.0.4",
     "patternfly": "3.30.1",
     "phantomjs-prebuilt": "2.1.15",
@@ -157,6 +165,7 @@
     "reflect-metadata": "0.1.10",
     "rimraf": "2.6.2",
     "run-sequence": "2.2.0",
+    "rxjs": "^5.5.2",
     "script-ext-html-webpack-plugin": "1.8.7",
     "semantic-release": "8.2.0",
     "style-loader": "0.19.0",


### PR DESCRIPTION
related to openshiftio/openshift.io#3686

Move angular, rxjs, some osio ngx-* from `dependencies` to `peerDependencies`.

`npm link --production` must be used to omit installation of `devDependencies` when linking.